### PR TITLE
New break line when copy element of pluggin

### DIFF
--- a/classes/ui.js
+++ b/classes/ui.js
@@ -183,6 +183,6 @@ const UI = {
             style="ui_style">@${item.author.login}</a></em><br>
             `
 
-    return (resultado += '</div>')
+    return (resultado += '</div><br/>')
   }
 }


### PR DESCRIPTION
Fixed issue when you had copy the text from pluggin, just don'd break the row after section